### PR TITLE
Add strict newline handling for translation output

### DIFF
--- a/src/domain/services/TranslationCore.test.ts
+++ b/src/domain/services/TranslationCore.test.ts
@@ -2,10 +2,24 @@ import { describe, expect, it } from 'vitest';
 import { TranslationCore } from './TranslationCore';
 
 describe('TranslationCore.splitIntoSentences', () => {
-  it('trims edges, collapses newlines, and removes empty sentences', () => {
+  it('treats each non-empty line as one sentence when newlines exist', () => {
     const core = new TranslationCore();
-    const result = core.splitIntoSentences('\n  This is a pen.\n\nBut this is not mine. \n\n');
+    const result = core.splitIntoSentences('\n  This is a pen.\n\nBut this is not mine. \n  ');
 
     expect(result).toEqual(['This is a pen.', 'But this is not mine.']);
+  });
+
+  it('falls back to punctuation splitting for a single-line paragraph', () => {
+    const core = new TranslationCore();
+    const result = core.splitIntoSentences('This is a pen. But this is not mine.');
+
+    expect(result).toEqual(['This is a pen.', 'But this is not mine.']);
+  });
+
+  it('keeps bullet-like lines as separate sentences even without punctuation', () => {
+    const core = new TranslationCore();
+    const result = core.splitIntoSentences('A short heading\nAnother bullet line\nFinal bullet');
+
+    expect(result).toEqual(['A short heading', 'Another bullet line', 'Final bullet']);
   });
 });

--- a/src/domain/services/TranslationCore.ts
+++ b/src/domain/services/TranslationCore.ts
@@ -41,9 +41,18 @@ export class TranslationCore {
    */
   splitIntoSentences(text: string): string[] {
     if (!text) return [];
-    const normalized = text.trim().replace(/\s*\n+\s*/g, ' ');
+    const normalized = text.replace(/\r\n/g, '\n').trim();
     if (!normalized) return [];
-    // Basic regex for sentence splitting
+
+    // strict newline mode: if at least one newline exists, each line is treated as one sentence.
+    if (normalized.includes('\n')) {
+      return normalized
+        .split('\n')
+        .map((line) => line.trim())
+        .filter((line) => line.length > 0);
+    }
+
+    // Fallback: basic punctuation splitting for a single-line paragraph.
     return normalized
       .split(/(?<=[.!?])\s+/)
       .map((sentence) => sentence.trim())

--- a/src/infrastructure/ai/MockTranslatorGateway.ts
+++ b/src/infrastructure/ai/MockTranslatorGateway.ts
@@ -1,14 +1,13 @@
 import { TranslatorGateway } from "../../application/ports/TranslatorGateway";
 import { TranslationPair } from "../../domain/entities";
+import { TranslationCore } from "../../domain/services/TranslationCore";
 
 export class MockTranslatorGateway implements TranslatorGateway {
+  private translationCore = new TranslationCore();
+
   async translate(text: string): Promise<TranslationPair[]> {
     // Mock translation logic: simulated split and append " [Translated]"
-    const normalized = text.trim().replace(/\s*\n+\s*/g, ' ');
-    const sentences = normalized
-      .split(/(?<=[.!?])\s+/)
-      .map((sentence) => sentence.trim())
-      .filter((sentence) => sentence.length > 0);
+    const sentences = this.translationCore.splitIntoSentences(text);
     return sentences.map(s => ({
       en: s,
       ja: `${s} [翻訳済み]`

--- a/src/infrastructure/ai/MultiProviderTranslatorOrchestrator.ts
+++ b/src/infrastructure/ai/MultiProviderTranslatorOrchestrator.ts
@@ -3,6 +3,7 @@ import { TranslationPair } from "../../domain/entities";
 import { SettingsRepository } from "../../application/ports/SettingsRepository";
 import { GeminiTranslatorGateway } from "./GeminiTranslatorGateway";
 import { OpenAITranslatorGateway } from "./OpenAITranslatorGateway";
+import { TranslationCore } from "../../domain/services/TranslationCore";
 
 /**
  * Orchestrates multiple AI translation providers with:
@@ -12,6 +13,7 @@ import { OpenAITranslatorGateway } from "./OpenAITranslatorGateway";
  */
 export class MultiProviderTranslatorOrchestrator implements TranslatorGateway {
   private lastUsedProvider: 'gemini' | 'openai' = 'openai'; // Start with openai so first call goes to gemini
+  private translationCore = new TranslationCore();
 
   constructor(private settingsRepository: SettingsRepository) {}
 
@@ -88,8 +90,7 @@ export class MultiProviderTranslatorOrchestrator implements TranslatorGateway {
   }
 
   private async webTranslateFallback(text: string): Promise<TranslationPair[]> {
-    // Simple sentence splitting
-    const sentences = text.match(/[^.!?]+[.!?]+/g) || [text];
+    const sentences = this.translationCore.splitIntoSentences(text);
     const results: TranslationPair[] = [];
 
     for (const sentence of sentences) {


### PR DESCRIPTION
## Summary
- enforce stricter newline preservation so each input line stays separate in translated text
- refresh mockups/docs and update UI, infrastructure, and translation services to support the new behavior

## Testing
- Not run (not requested)