### PR TITLE
docs: add onboarding and day1 code reading guides

### DIFF
--- a/docs/onboarding_reactnative_tamagui_electron_ja.md
+++ b/docs/onboarding_reactnative_tamagui_electron_ja.md
@@ -1,0 +1,134 @@
+# ParaLingo コードリーディング入門
+
+対象:
+- React Native Web 初学者
+- Tamagui 初学者
+- Electron 初学者
+
+目的:
+- 「このプロジェクトがどこで何をしているか」を1日で掴む
+- 機能開発せずに、安心して読み進める
+
+---
+
+## 1. このアプリの技術の役割
+
+- Electron: デスクトップアプリの外側（ウィンドウ、グローバルショートカット、IPC）
+- React Native Web: UIをReactコンポーネントで構築（Webとして描画）
+- Tamagui: React Native風コンポーネント + デザイントークンでUIを組む
+
+実態:
+- 「Electronの中でWeb UI（React Native Web + Tamagui）を動かす」構成
+
+---
+
+## 2. 最初に読むべき実行フロー（全体像）
+
+1. `Command+Shift+T` を押す
+2. Electron Main がショートカットを受ける
+3. Clipboardの英文をUseCaseで翻訳
+4. 翻訳結果をIPCイベントでUIへ渡す
+5. Reading / Practice / Review 画面が表示更新
+
+対応ファイル:
+- Main起動: `src/main.ts`
+- IPCとショートカット: `src/interface/electron-main/index.ts`
+- Preload(安全な橋渡し): `src/interface/electron-main/preload.ts`
+- UseCase: `src/application/use-cases/RunTranslationFromClipboard.ts`
+- 翻訳ゲートウェイ: `src/infrastructure/ai/*TranslatorGateway.ts`
+- UIエントリ: `src/interface/ui/index.tsx`
+- Reading画面: `src/interface/ui/TranslationOverlay.tsx`
+- Practice画面: `src/interface/ui/PracticeScreen.tsx`
+- Review画面: `src/interface/ui/ReviewScreen.tsx`
+
+---
+
+## 3. レイヤーごとの責務（Clean Architecture寄り）
+
+- `domain/`: 型・ルール（エンティティ、分割ロジック）
+- `application/`: ユースケース（何をするか）
+- `infrastructure/`: 外部接続（Gemini/OpenAI/SQLite/OS）
+- `interface/`: Electron IPC と UI（見せ方・入力）
+
+読み方のコツ:
+- 「どこで判定するべきか」を意識
+- 例: 文分割は `domain/services/TranslationCore.ts` にある
+
+---
+
+## 4. 60-90分の読み順（今日用）
+
+1. `src/main.ts`
+2. `src/interface/electron-main/index.ts`
+3. `src/interface/electron-main/preload.ts`
+4. `src/application/use-cases/RunTranslationFromClipboard.ts`
+5. `src/infrastructure/ai/MultiProviderTranslatorOrchestrator.ts`
+6. `src/infrastructure/ai/GeminiTranslatorGateway.ts`
+7. `src/domain/services/TranslationCore.ts`
+8. `src/interface/ui/index.tsx`
+9. `src/interface/ui/TranslationOverlay.tsx`
+10. `src/interface/ui/PracticeScreen.tsx`
+11. `src/interface/ui/ReviewScreen.tsx`
+
+---
+
+## 5. まず覚える最重要ポイント
+
+### Electronの文脈分離
+- Renderer(UI)からNode APIを直接触らない
+- `preload.ts` 経由で `window.paralingo.*` だけを使う
+
+### UI状態の保持
+- タブ切替はアンマウントでなく `display` 切替
+- 画面を戻っても状態が残る理由はここ
+
+### 翻訳データの流れ
+- 翻訳結果は `onTranslationResult` イベントで各画面に届く
+- Reading/Practiceはこのイベントを購読して表示更新
+
+---
+
+## 6. よく詰まるポイント
+
+- 「動くが値が出ない」:
+  - IPC名のミスマッチ（`save-review-item` など）を確認
+- 「ビルドは通るが画面型エラー」:
+  - フロントはViteビルド時に厳密型チェックされない場合がある
+- 「古い表示が残る」:
+  - どのstateをリセットするか（loading時/close時）を確認
+
+---
+
+## 7. 便利コマンド
+
+```bash
+# 開発起動（frontend + electron）
+npm run start
+
+# テスト実行
+npm test -- --run
+
+# 本番ビルド確認
+npm run build
+```
+
+---
+
+## 8. コードリーディングの着眼点（メモ推奨）
+
+- 入力: どこから来るか（ショートカット/クリップボード）
+- 変換: どこで加工するか（文分割/翻訳/整形）
+- 出力: どこへ渡すか（IPCイベント/UI state）
+- 失敗時: どこでfallbackするか（Provider failover/Web fallback）
+
+---
+
+## 9. 次に読むと理解が深まる資料
+
+- `docs/clean_architecture_mapping_ja.md`
+- `docs/mvp_spec_ja.md`
+- `docs/mac_os_resident_v1_design.md`
+
+---
+
+この資料のゴールは「改修する前に、迷わず追える状態になること」です。

--- a/docs/reading_files_day1_ja.md
+++ b/docs/reading_files_day1_ja.md
@@ -1,0 +1,63 @@
+# 明日読む: 具体的ファイル10選（ParaLingo）
+
+目的:
+- 実装より先に「流れ」を掴む
+- どこで何が起きるかを説明できるようになる
+
+読む順番（この順でOK）
+
+1. `src/main.ts`
+- 何を見るか: Electronウィンドウの初期化、表示設定、Tray連携
+- チェック: `BrowserWindow` の `webPreferences` と `frame/alwaysOnTop`
+
+2. `src/interface/electron-main/index.ts`
+- 何を見るか: グローバルショートカット、IPCハンドラ、翻訳実行の入口
+- チェック: `run-translation`, `save-review-item`, `list-review-items`
+
+3. `src/interface/electron-main/preload.ts`
+- 何を見るか: Rendererに公開している `window.paralingo` API
+- チェック: Main側のIPC名と一致しているか
+
+4. `src/application/use-cases/RunTranslationFromClipboard.ts`
+- 何を見るか: クリップボード取得 -> trim -> 翻訳呼び出し
+- チェック: 空入力時のエラー処理
+
+5. `src/domain/services/TranslationCore.ts`
+- 何を見るか: 文分割ルール（strict newline）とレスポンススキーマ
+- チェック: 改行優先の分割挙動
+
+6. `src/infrastructure/ai/MultiProviderTranslatorOrchestrator.ts`
+- 何を見るか: gemini/openai の順序、failover、web fallback
+- チェック: `auto` モード時の切替ロジック
+
+7. `src/infrastructure/ai/GeminiTranslatorGateway.ts`
+- 何を見るか: プロンプト設計、JSONパース、発音情報補完
+- チェック: `ipa/katakana/pronunciationNotes` の生成と補完
+
+8. `src/infrastructure/ai/OpenAITranslatorGateway.ts`
+- 何を見るか: OpenAI版の同等ロジック
+- チェック: Gemini実装との差分（API呼び出し部）
+
+9. `src/interface/ui/index.tsx`
+- 何を見るか: タブ構成（Reading/Practice/Review/Settings）と表示切替
+- チェック: `display` 切替で状態保持している点
+
+10. `src/interface/ui/TranslationOverlay.tsx`
+- 何を見るか: Reading本体UI、翻訳結果反映、Review保存導線
+- チェック: `onTranslationResult` のstate更新
+
+---
+
+## 余力があれば（+3）
+
+- `src/interface/ui/PracticeScreen.tsx`
+- `src/interface/ui/ReviewScreen.tsx`
+- `src/infrastructure/db/SQLiteVocabRepository.ts`
+
+---
+
+## 明日のゴール（30秒で自己評価）
+
+- 「ショートカット押下からUI表示まで」を口頭で説明できる
+- 「どこで分割・翻訳・保存しているか」をファイル名で言える
+- 「不具合時に最初に見るファイル」を3つ挙げられる


### PR DESCRIPTION
## Summary
- add onboarding guide for React Native Web + Tamagui + Electron
- add day1 file-by-file reading guide (10 files)

## Files
- docs/onboarding_reactnative_tamagui_electron_ja.md
- docs/reading_files_day1_ja.md
